### PR TITLE
Hotfix for recovery page and refactoring

### DIFF
--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -4,6 +4,9 @@ local utils = require("kong.plugins.oidc.utils")
 local filter = require("kong.plugins.oidc.filter")
 local session = require("kong.plugins.oidc.session")
 
+local openidc = require("resty.openidc")
+local cjson = require("cjson")
+
 OidcHandler.PRIORITY = 1000
 
 
@@ -17,9 +20,8 @@ function OidcHandler:access(config)
 
   if filter.shouldProcessRequest(oidcConfig) then
     ngx.log(ngx.DEBUG, "In plugin OidcHandler:access calling authenticate, requested path: " .. ngx.var.request_uri)
-
     session.configure(config)
-    doAuthentication(oidcConfig)
+    handle(oidcConfig)
   else
     ngx.log(ngx.DEBUG, "In plugin OidcHandler:access NOT calling authenticate, requested path: " .. ngx.var.request_uri)
   end
@@ -27,42 +29,51 @@ function OidcHandler:access(config)
   ngx.log(ngx.DEBUG, "In plugin OidcHandler:access Done")
 end
 
+function handle(oidcConfig)
+  local response = nil
+  if oidcConfig.introspection_endpoint then
+    response = introspect(oidcConfig)
+    if response then
+      utils.injectUser(response)
+    end
+  end
+
+  if response == nil then
+    response = make_oidc(oidcConfig)
+    if response and response.user then
+      utils.injectUser(response.user)
+      ngx.req.set_header("X-Userinfo", cjson.encode(response.user))
+    end
+  end
+
+end
+
 function doAuthentication(oidcConfig)
-  res = tryIntrospect(oidcConfig)
-
-  if res then
-    ngx.log(ngx.DEBUG, "In plugin OidcHandler:Valid access token detected, passing connection, requested path: " .. ngx.var.request_uri)
-    utils.injectUser({sub = res.sub})
-    
-  else
-    local res, err = require("resty.openidc").authenticate(oidcConfig)
-    if err then
-      if oidcConfig.recovery_page_path then
-        ngx.log(ngx.DEBUG, "Entering recovery page: " .. oidcConfig.recovery_page_path)
-        ngx.redirect(oidcConfig.recovery_page_path)
-      end
-      utils.exit(500, err, ngx.HTTP_INTERNAL_SERVER_ERROR)
-    end
-
-    if res and res.user then
-      utils.injectUser(res.user)
-      ngx.req.set_header("X-Userinfo", require("cjson").encode(res.user))
-    end
+  if res and res.user then
+    utils.injectUser(res.user)
+    ngx.req.set_header("X-Userinfo", require("cjson").encode(res.user))
   end
 end
 
-function tryIntrospect(oidcConfig)
-  if not oidcConfig.introspection_endpoint then
-    return nil
+function make_oidc(oidcConfig)
+  local res, err = openidc.authenticate(oidcConfig)
+  if err then
+    if oidcConfig.recovery_page_path then
+      ngx.log(ngx.DEBUG, "Entering recovery page: " .. oidcConfig.recovery_page_path)
+      ngx.redirect(oidcConfig.recovery_page_path)
+    end
+    utils.exit(500, err, ngx.HTTP_INTERNAL_SERVER_ERROR)
   end
-  
-  local res, err = require("resty.openidc").introspect(oidcConfig)
+  return res
+end
+
+function introspect(oidcConfig)
+  local res, err = openidc.introspect(oidcConfig)
   if err then
     return nil
   end
-
   return res
 end
 
 
-return CustomHandler
+return OidcHandler

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -45,14 +45,6 @@ function handle(oidcConfig)
       ngx.req.set_header("X-Userinfo", cjson.encode(response.user))
     end
   end
-
-end
-
-function doAuthentication(oidcConfig)
-  if res and res.user then
-    utils.injectUser(res.user)
-    ngx.req.set_header("X-Userinfo", require("cjson").encode(res.user))
-  end
 end
 
 function make_oidc(oidcConfig)

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -1,60 +1,45 @@
--- Extending the Base Plugin handler is optional, as there is no real
--- concept of interface in Lua, but the Base Plugin handler's methods
--- can be called from your child implementation and will print logs
--- in your `error.log` file (where all logs are printed).
 local BasePlugin = require "kong.plugins.base_plugin"
-local CustomHandler = BasePlugin:extend()
+local OidcHandler = BasePlugin:extend()
 local utils = require("kong.plugins.oidc.utils")
 local filter = require("kong.plugins.oidc.filter")
 local session = require("kong.plugins.oidc.session")
 
-CustomHandler.PRIORITY = 1000
+OidcHandler.PRIORITY = 1000
 
--- Your plugin handler's constructor. If you are extending the
--- Base Plugin handler, it's only role is to instanciate itself
--- with a name. The name is your plugin name as it will be printed in the logs.
-function CustomHandler:new()
-  CustomHandler.super.new(self, "oidc")
+
+function OidcHandler:new()
+  OidcHandler.super.new(self, "oidc")
 end
 
-function CustomHandler:access(config)
-  -- Eventually, execute the parent implementation
-  -- (will log that your plugin is entering this context)
-  CustomHandler.super.access(self)
-
+function OidcHandler:access(config)
+  OidcHandler.super.access(self)
   local oidcConfig = utils.get_options(config, ngx)
 
   if filter.shouldProcessRequest(oidcConfig) then
-    ngx.log(ngx.DEBUG, "In plugin CustomHandler:access calling authenticate, requested path: " .. ngx.var.request_uri)
+    ngx.log(ngx.DEBUG, "In plugin OidcHandler:access calling authenticate, requested path: " .. ngx.var.request_uri)
 
     session.configure(config)
-
     doAuthentication(oidcConfig)
-
   else
-    ngx.log(ngx.DEBUG, "In plugin CustomHandler:access NOT calling authenticate, requested path: " .. ngx.var.request_uri)
+    ngx.log(ngx.DEBUG, "In plugin OidcHandler:access NOT calling authenticate, requested path: " .. ngx.var.request_uri)
   end
 
-  ngx.log(ngx.DEBUG, "In plugin CustomHandler:access Done")
+  ngx.log(ngx.DEBUG, "In plugin OidcHandler:access Done")
 end
 
 function doAuthentication(oidcConfig)
-
   res = tryIntrospect(oidcConfig)
+
   if res then
-
-    ngx.log(ngx.DEBUG, "In plugin CustomHandler:Valid access token detected, passing connection, requested path: " .. ngx.var.request_uri)
-
+    ngx.log(ngx.DEBUG, "In plugin OidcHandler:Valid access token detected, passing connection, requested path: " .. ngx.var.request_uri)
     utils.injectUser({sub = res.sub})
-
+    
   else
-
     local res, err = require("resty.openidc").authenticate(oidcConfig)
-
     if err then
-      if config.recovery_page_path then
-        ngx.log(ngx.DEBUG, "Entering recovery page: " .. config.recovery_page_path)
-        return ngx.redirect(config.recovery_page_path)
+      if oidcConfig.recovery_page_path then
+        ngx.log(ngx.DEBUG, "Entering recovery page: " .. oidcConfig.recovery_page_path)
+        ngx.redirect(oidcConfig.recovery_page_path)
       end
       utils.exit(500, err, ngx.HTTP_INTERNAL_SERVER_ERROR)
     end
@@ -63,14 +48,10 @@ function doAuthentication(oidcConfig)
       utils.injectUser(res.user)
       ngx.req.set_header("X-Userinfo", require("cjson").encode(res.user))
     end
-
   end
-
 end
 
 function tryIntrospect(oidcConfig)
-  
-  -- If introspection endpoint is not set, the functionallity is considered as disabled
   if not oidcConfig.introspection_endpoint then
     return nil
   end
@@ -81,9 +62,7 @@ function tryIntrospect(oidcConfig)
   end
 
   return res
-
 end
 
--- This module needs to return the created table, so that Kong
--- can execute those functions.
+
 return CustomHandler

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -60,8 +60,10 @@ function M.exit(httpStatusCode, message, ngxCode)
 end
 
 function M.injectUser(user)
-  ngx.ctx.authenticated_consumer = user
-  ngx.ctx.authenticated_consumer.id = user.sub
+  local tmp_user = user
+  tmp_user.id = user.sub
+  tmp_user.username = user.preferred_username
+  ngx.ctx.authenticated_consumer = tmp_user
 end
 
 return M


### PR DESCRIPTION
That's a hotfix for the problem with recovery page. There was a wrong variable in the function (`config` instead of `oidcConfig`)