### PR TITLE
To enable the plugin globally: /apis -> /plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you're using `luarocks` execute the following:
 You also need to set the `KONG_CUSTOM_PLUGINS` environment variable
 
      export KONG_CUSTOM_PLUGINS=oidc
-     
+
 ## Usage
 
 ### Parameters
@@ -89,7 +89,7 @@ name=oidc&config.client_id=kong-oidc&config.client_secret=29d98bf7-168c-4874-b8e
 
 To enable the plugin globally:
 ```
-POST /apis HTTP/1.1
+POST /plugins HTTP/1.1
 Host: localhost:8001
 Content-Type: application/x-www-form-urlencoded
 Cache-Control: no-cache


### PR DESCRIPTION
There is an error on readme.md
> To enable the plugin globally: 
> /apis

Should be the url '/plugins'