### PR TITLE
Utilize redirect_uri_path from config

### DIFF
--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -43,7 +43,7 @@ function M.get_options(config, ngx)
     client_secret = config.client_secret,
     discovery = config.discovery,
     introspection_endpoint = config.introspection_endpoint,
-    redirect_uri_path = M.get_redirect_uri_path(ngx),
+    redirect_uri_path = config.redirect_uri_path or M.get_redirect_uri_path(ngx),
     scope = config.scope,
     response_type = config.response_type,
     ssl_verify = config.ssl_verify,


### PR DESCRIPTION
Hello!

I noticed that the config schema had the params for `redirect_uri_path`, but the plugin wasn't passing it through to `lua-resty-openidc`. This updates it so that it will utilize the config if it is set, and otherwise fallback to the original behavior.

My use case for this is that I am trying to integrate with `identityserver.io`, which has very strict restrictions on the `redirect_uri` (for [good reasons](https://github.com/IdentityServer/IdentityServer3/issues/245)), and thus it becomes near impossible because all API uris must be registered. This allows for registering just a single endpoint that is used as the callback, which will autoforward to the originally requested uri as done by `lua-resty-openidc`.