### PR TITLE
Replace authenticated_consumer with authenticated_credential

### DIFF
--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -63,7 +63,7 @@ function M.injectUser(user)
   local tmp_user = user
   tmp_user.id = user.sub
   tmp_user.username = user.preferred_username
-  ngx.ctx.authenticated_consumer = tmp_user
+  ngx.ctx.authenticated_credential = tmp_user
 end
 
 function M.has_bearer_access_token()

--- a/test/unit/test_handler_mocking_openidc.lua
+++ b/test/unit/test_handler_mocking_openidc.lua
@@ -39,7 +39,7 @@ function TestHandler:test_authenticate_ok_with_userinfo()
 
   self.handler:access({})
   lu.assertTrue(self:log_contains("calling authenticate"))
-  lu.assertEquals(ngx.ctx.authenticated_consumer.id, "sub")
+  lu.assertEquals(ngx.ctx.authenticated_credential.id, "sub")
 end
 
 function TestHandler:test_authenticate_nok_no_recovery()


### PR DESCRIPTION
Fix for #38 
`authenticated_consumer` should be used only, when the consumer is registered in Kong. For consumers not registered in kong `authenticated_credential` should be used, which is true in case of external OIDC Providers.