### PR TITLE
Update lua-resty-openidc to 1.6.0 and encode X-Userinfo header in base64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,19 @@
 
 language: python
 
-sudo: false
+sudo: true
 
 env:
-  - LUA_VERSION="5.1" KONG_VERSION="0.13.0-0" LUA_RESTY_OPENIDC_VERSION="1.5.3"
-  - LUA_VERSION="5.1" KONG_VERSION="0.12.3-0" LUA_RESTY_OPENIDC_VERSION="1.5.3"
-  - LUA_VERSION="5.1" KONG_VERSION="0.11.2-0" LUA_RESTY_OPENIDC_VERSION="1.5.3"
+  - LUA_VERSION="5.1" KONG_VERSION="0.13.0-0" LUA_RESTY_OPENIDC_VERSION="1.6.0"
+  - LUA_VERSION="5.1" KONG_VERSION="0.12.3-0" LUA_RESTY_OPENIDC_VERSION="1.6.0"
+  - LUA_VERSION="5.1" KONG_VERSION="0.11.2-0" LUA_RESTY_OPENIDC_VERSION="1.6.0"
 
 script:
-  - source ci/run.sh
+  - sudo -E bash ci/root.sh
+  - . ci/setup.sh
+  - . ci/run.sh
 
 after_success:
   - luarocks install luacov-coveralls
   - luacov-coveralls
+

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Server: kong/0.11.0
 
 ### Upstream API request
 
-The plugin adds a additional `X-Userinfo` header to the upstream request, which can be consumer by upstream server:
+The plugin adds a additional `X-Userinfo` header to the upstream request, which can be consumer by upstream server. It contains Userinfo base64 encoded:
 
 ```
 GET / HTTP/1.1
@@ -152,7 +152,7 @@ Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/a
 Accept-Encoding: gzip, deflate
 Accept-Language: pl-PL,pl;q=0.8,en-US;q=0.6,en;q=0.4
 Cookie: session=KOn1am4mhQLKazlCA.....
-X-Userinfo: {"preferred_username":"alice","id":"60f65308-3510-40ca-83f0-e9c0151cc680","sub":"60f65308-3510-40ca-83f0-e9c0151cc680"}
+X-Userinfo: eyJnaXZlbl9uYW1lIjoixITEmMWaw5PFgcW7xbnEhiIsInN1YiI6ImM4NThiYzAxLTBiM2ItNDQzNy1hMGVlLWE1ZTY0ODkwMDE5ZCIsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIiwibmFtZSI6IsSExJjFmsOTxYHFu8W5xIYiLCJ1c2VybmFtZSI6ImFkbWluIiwiaWQiOiJjODU4YmMwMS0wYjNiLTQ0MzctYTBlZS1hNWU2NDg5MDAxOWQifQ==
 ```
 
 

--- a/ci/root.sh
+++ b/ci/root.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+apt-get update
+apt-get install -y curl unzip libssl-dev python python-pip git
+

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,25 +1,10 @@
 #!/bin/bash
-
-export LUA_VERSION=${LUA_VERSION:-5.1}
-export KONG_VERSION=${KONG_VERSION:-0.11.2-0}
-export LUA_RESTY_OPENIDC_VERSION=${LUA_RESTY_OPENIDC_VERSION:-1.5.3}
-
-apt-get update
-apt-get install -y unzip
-
-pip install hererocks
-hererocks lua_install -r^ --lua=${LUA_VERSION}
-export PATH=${PATH}:${PWD}/lua_install/bin
-
-luarocks install kong ${KONG_VERSION}
-luarocks install lua-resty-openidc ${LUA_RESTY_OPENIDC_VERSION}
-luarocks install lua-cjson
-luarocks install luaunit
-luarocks install luacov
+set -e
 
 lua -lluacov test/unit/test_filter.lua -o TAP --failure
 lua -lluacov test/unit/test_filters_advanced.lua -o TAP --failure
 lua -lluacov test/unit/test_utils.lua -o TAP --failure
-lua -lluacov test/unit/test_handler_mocking_openidc.lua --failure
+lua -lluacov test/unit/test_handler_mocking_openidc.lua -o TAP --failure
 lua -lluacov test/unit/test_introspect.lua -o TAP --failure
 lua -lluacov test/unit/test_utils_bearer_access_token.lua -o TAP --failure
+

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+export LUA_VERSION=${LUA_VERSION:-5.1}
+export KONG_VERSION=${KONG_VERSION:-0.13.1-0}
+export LUA_RESTY_OPENIDC_VERSION=${LUA_RESTY_OPENIDC_VERSION:-1.6.0}
+
+pip install hererocks
+hererocks lua_install -r^ --lua=${LUA_VERSION}
+export PATH=${PATH}:${PWD}/lua_install/bin
+
+luarocks install kong ${KONG_VERSION}
+luarocks install lua-resty-openidc ${LUA_RESTY_OPENIDC_VERSION}
+luarocks install lua-cjson
+luarocks install luaunit
+luarocks install luacov
+

--- a/kong-oidc-1.0.5-0.rockspec
+++ b/kong-oidc-1.0.5-0.rockspec
@@ -22,7 +22,7 @@ description = {
     license = "Apache 2.0"
 }
 dependencies = {
-    "lua-resty-openidc ~> 1.5.3"
+    "lua-resty-openidc ~> 1.6.0"
 }
 build = {
     type = "builtin",

--- a/kong-oidc-1.1.0-0.rockspec
+++ b/kong-oidc-1.1.0-0.rockspec
@@ -1,8 +1,8 @@
 package = "kong-oidc"
-version = "1.0.5-0"
+version = "1.1.0-0"
 source = {
     url = "git://github.com/nokia/kong-oidc",
-    tag = "v1.0.5",
+    tag = "v1.1.0",
     dir = "kong-oidc"
 }
 description = {

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -40,7 +40,8 @@ function handle(oidcConfig)
     response = make_oidc(oidcConfig)
     if response and response.user then
       utils.injectUser(response.user)
-      ngx.req.set_header("X-Userinfo", cjson.encode(response.user))
+      local userinfo = cjson.encode(response.user)
+      ngx.req.set_header("X-Userinfo", ngx.encode_base64(userinfo))
     end
   end
 end

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,4 @@
+FROM kong:0.13
+
+RUN luarocks install lua-resty-openidc
+

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3'
+services:
+  kong-db:
+    image: 'postgres:10.1'
+    ports:
+    - 5432:5432
+    environment:
+      POSTGRES_USER: kong
+      POSTGRES_PASSWORD: kong
+      POSTGRES_DB: kong
+
+  keycloak:
+    image: 'jboss/keycloak:3.4.0.Final'
+    ports:
+    - 8080:8080
+    environment:
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: password
+
+  kong:
+    build: .
+    ports:
+    - 8000:8000
+    - 8443:8443
+    - 8001:8001
+    - 8444:8444
+    #command: kong migrations up
+    environment:
+      KONG_DATABASE: postgres
+      KONG_PG_HOST: kong-db
+      KONG_PG_DATABASE: kong
+      KONG_PG_USER: kong
+      KONG_PG_PASSWORD: kong
+      KONG_ADMIN_LISTEN: "0.0.0.0:8001"
+      KONG_PROXY_ACCESS_LOG: /dev/stdout
+      KONG_ADMIN_ACCESS_LOG: /dev/stdout
+      KONG_PROXY_ERROR_LOG: /dev/stderr
+      KONG_ADMIN_ERROR_LOG: /dev/stderr
+      KONG_CUSTOM_PLUGINS: oidc
+    depends_on:
+      - kong-db
+    volumes:
+      - "../kong/plugins/oidc:/usr/local/openresty/site/lualib/kong/plugins/oidc"

--- a/test/setup.py
+++ b/test/setup.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+
+import os
+from collections import namedtuple
+
+import requests
+
+
+Config = namedtuple("Config", [
+    "keycloak_endpoint",
+    "keycloak_admin",
+    "keycloak_password",
+    "client_id",
+    "client_secret",
+    "discovery",
+])
+
+
+def get_config():
+    return Config(
+        keycloak_endpoint = os.getenv("KC_ENDPOINT", "http://keycloak:8080"),
+        keycloak_admin = os.getenv("KC_ADMIN", "admin"),
+        keycloak_password = os.getenv("KC_PASSWORD", "password"),
+        client_id = os.getenv("CLIENT_ID", "kong"),
+        client_secret = os.getenv("CLIENT_SECRET"),
+        discovery = os.getenv("KC_ENDPOINT", "http://keycloak:8080") + \
+            "/auth/realms/master/.well-known/openid-configuration",
+    )
+
+
+class KeycloakClient:
+    def __init__(self):
+        self._endpoint = "http://localhost:8080"
+        self._session = requests.session()
+
+    def create_client(self, name, secret):
+        config = get_config()
+        url = "{}/auth/admin/realms/master/clients".format(
+            config.keycloak_endpoint)
+        payload = {
+            "clientId": name,
+            "secret": secret,
+            "redirectUris": ["*"],
+        }
+
+        headers = self.get_auth_header()
+        res = self._session.post(url, json=payload, headers=headers)
+        if res.status_code not in [201, 409]:
+            raise Exception("Cannot create client")
+
+    def get_auth_header(self):
+        return {
+            "Authorization": "Bearer {}".format(self.get_admin_token())
+        }
+
+    def get_admin_token(self):
+        config = get_config()
+        url = "{}/auth/realms/master/protocol/openid-connect/token".format(
+            config.keycloak_endpoint)
+        payload = "client_id=admin-cli&grant_type=password" + \
+            "&username={}&password={}".format(config.keycloak_admin,
+                                             config.keycloak_password
+                                             )
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded"
+        }
+        res = self._session.post(url, data=payload, headers=headers)
+        res.raise_for_status()
+        return res.json()["access_token"]
+
+
+class KongClient:
+    def __init__(self):
+        self._endpoint = "http://localhost:8001"
+        self._session = requests.session()
+
+    def create_service(self, name, upstream_url):
+        url = "{}/services".format(self._endpoint)
+        payload = {
+            "name": name,
+            "url": upstream_url,
+        }
+        res = self._session.post(url, json=payload)
+        res.raise_for_status()
+        return res.json()
+
+    def create_route(self, service_name, paths):
+        url = "{}/services/{}/routes".format(self._endpoint, service_name)
+        payload = {
+            "paths": paths,
+        }
+        res = self._session.post(url, json=payload)
+        res.raise_for_status()
+        return res.json()
+
+    def create_plugin(self, plugin_name, service_name, config):
+        url = "{}/services/{}/plugins".format(self._endpoint, service_name)
+        payload = {
+            "name": plugin_name,
+            "config": config,
+        }
+        res = self._session.post(url, json=payload)
+        try:
+            res.raise_for_status()
+        except Exception as e:
+            print(res.text)
+            raise e
+        return res.json()
+
+    def delete_service(self, name):
+        try:
+            routes = self.get_routes(name)
+            for route in routes:
+                self.delete_route(route)
+        except requests.exceptions.HTTPError:
+            pass
+        url = "{}/services/{}".format(self._endpoint, name)
+        self._session.delete(url).raise_for_status()
+
+    def delete_route(self, route_id):
+        url = "{}/routes/{}".format(self._endpoint, route_id)
+        self._session.delete(url).raise_for_status()
+
+    def get_routes(self, service_name):
+        url = "{}/services/{}/routes".format(self._endpoint, service_name)
+        res = self._session.get(url)
+        res.raise_for_status()
+        return map(lambda x: x['id'], res.json()['data'])
+
+
+config = get_config()
+
+kc_client = KeycloakClient()
+kc_client.create_client(config.client_id, config.client_secret)
+
+kong_client = KongClient()
+kong_client.delete_service("httpbin")
+kong_client.create_service("httpbin", "http://httpbin.org")
+kong_client.create_route("httpbin", ["/httpbin"])
+kong_client.create_plugin("oidc", "httpbin", {
+    "client_id": config.client_id,
+    "client_secret": config.client_secret,
+    "discovery": config.discovery,
+    "logout_path": "/httpbin/logout",
+})
+

--- a/test/unit/test_handler_mocking_openidc.lua
+++ b/test/unit/test_handler_mocking_openidc.lua
@@ -33,6 +33,10 @@ function TestHandler:test_authenticate_ok_with_userinfo()
   self.module_resty.openidc.authenticate = function(opts)
     return {user = {sub = "sub"}}, false
   end
+  ngx.encode_base64 = function(x)
+    return "eyJzdWIiOiJzdWIifQ=="
+  end
+
   ngx.req.set_header = function(h, v)
     lu.assertEquals(h, "X-Userinfo")
   end


### PR DESCRIPTION
Fixes #47 and #52.

Fixing #52 required to break backward compatibility with 1.0.4. The X-Userinfo header is now base64 encoded. Using UTF-8 characters in HTTP headers isn't a good solution overall (https://tools.ietf.org/html/rfc7230#section-3.2.4).

@arun2dot0, @nbkntu, can you check, if this PR solves your issues?

@phirvone, @tsyrjanen, @pag-r