### PR TITLE
Upgrade to lua-resty-openidc 1.5.4

### DIFF
--- a/kong-oidc-1.0.5-0.rockspec
+++ b/kong-oidc-1.0.5-0.rockspec
@@ -22,7 +22,7 @@ description = {
     license = "Apache 2.0"
 }
 dependencies = {
-    "lua-resty-openidc ~> 1.5.3"
+    "lua-resty-openidc ~> 1.5.4"
 }
 build = {
     type = "builtin",


### PR DESCRIPTION
Among other thing this brings a fix for a nasty token signature verification error: https://github.com/zmartzone/lua-resty-openidc/pull/153 