### PR TITLE
Timeout for OIDC calls to external endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You also need to set the `KONG_CUSTOM_PLUGINS` environment variable
 | `config.ssl_verify` | false | false | Enable SSL verification to OIDC Provider |
 | `config.session_secret` | | false | Additional parameter, which is used to encrypt the session cookie. Needs to be random |
 | `config.introspection_endpoint` | | false | Token introspection endpoint |
-| `config.timeout` | | false | Token introspection timeout |
+| `config.timeout` | | false | OIDC endpoint calls timeout |
 | `config.introspection_endpoint_auth_method` | client_secret_basic | false | Token introspection auth method. resty-openidc supports `client_secret_(basic|post)` |
 | `config.bearer_only` | no | false | Only introspect tokens without redirecting |
 | `config.realm` | kong | false | Realm used in WWW-Authenticate response header |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You also need to set the `KONG_CUSTOM_PLUGINS` environment variable
 | `config.ssl_verify` | false | false | Enable SSL verification to OIDC Provider |
 | `config.session_secret` | | false | Additional parameter, which is used to encrypt the session cookie. Needs to be random |
 | `config.introspection_endpoint` | | false | Token introspection endpoint |
-| `config.introspection_timeout` | | false | Token introspection timeout |
+| `config.timeout` | | false | Token introspection timeout |
 | `config.introspection_endpoint_auth_method` | client_secret_basic | false | Token introspection auth method. resty-openidc supports `client_secret_(basic|post)` |
 | `config.bearer_only` | no | false | Only introspect tokens without redirecting |
 | `config.realm` | kong | false | Realm used in WWW-Authenticate response header |

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ You also need to set the `KONG_CUSTOM_PLUGINS` environment variable
 | `config.ssl_verify` | false | false | Enable SSL verification to OIDC Provider |
 | `config.session_secret` | | false | Additional parameter, which is used to encrypt the session cookie. Needs to be random |
 | `config.introspection_endpoint` | | false | Token introspection endpoint |
+| `config.introspection_timeout` | | false | Token introspection timeout |
 | `config.introspection_endpoint_auth_method` | client_secret_basic | false | Token introspection auth method. resty-openidc supports `client_secret_(basic|post)` |
 | `config.bearer_only` | no | false | Only introspect tokens without redirecting |
 | `config.realm` | kong | false | Realm used in WWW-Authenticate response header |

--- a/kong-oidc-1.1.0-0.rockspec
+++ b/kong-oidc-1.1.0-0.rockspec
@@ -1,7 +1,7 @@
 package = "kong-oidc"
 version = "1.1.0-0"
 source = {
-    url = "git://github.com/nokia/kong-oidc",
+    url = "git://github.com/xwrs/kong-oidc",
     tag = "v1.1.0",
     dir = "kong-oidc"
 }
@@ -18,7 +18,7 @@ description = {
 
         It can be used as a reverse proxy terminating OAuth/OpenID Connect in front of an origin server so that the origin server/services can be protected with the relevant standards without implementing those on the server itself.
     ]],
-    homepage = "https://github.com/nokia/kong-oidc",
+    homepage = "https://github.com/xwrs/kong-oidc",
     license = "Apache 2.0"
 }
 dependencies = {

--- a/kong-oidc-1.1.0-0.rockspec
+++ b/kong-oidc-1.1.0-0.rockspec
@@ -1,7 +1,7 @@
 package = "kong-oidc"
 version = "1.1.0-0"
 source = {
-    url = "git://github.com/xwrs/kong-oidc",
+    url = "git://github.com/nokia/kong-oidc",
     tag = "v1.1.0",
     dir = "kong-oidc"
 }
@@ -18,7 +18,7 @@ description = {
 
         It can be used as a reverse proxy terminating OAuth/OpenID Connect in front of an origin server so that the origin server/services can be protected with the relevant standards without implementing those on the server itself.
     ]],
-    homepage = "https://github.com/xwrs/kong-oidc",
+    homepage = "https://github.com/nokia/kong-oidc",
     license = "Apache 2.0"
 }
 dependencies = {

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -5,7 +5,7 @@ return {
     client_secret = { type = "string", required = true },
     discovery = { type = "string", required = true, default = "https://.well-known/openid-configuration" },
     introspection_endpoint = { type = "string", required = false },
-    introspection_timeout = { type = "number", required = false },
+    timeout = { type = "number", required = false },
     introspection_endpoint_auth_method = { type = "string", required = false },
     bearer_only = { type = "string", required = true, default = "no" },
     realm = { type = "string", required = true, default = "kong" },

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -5,6 +5,7 @@ return {
     client_secret = { type = "string", required = true },
     discovery = { type = "string", required = true, default = "https://.well-known/openid-configuration" },
     introspection_endpoint = { type = "string", required = false },
+    introspection_timeout = { type = "number", required = false },
     introspection_endpoint_auth_method = { type = "string", required = false },
     bearer_only = { type = "string", required = true, default = "no" },
     realm = { type = "string", required = true, default = "kong" },

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -45,6 +45,7 @@ function M.get_options(config, ngx)
     client_secret = config.client_secret,
     discovery = config.discovery,
     introspection_endpoint = config.introspection_endpoint,
+    timeout = config.introspection_timeout,
     introspection_endpoint_auth_method = config.introspection_endpoint_auth_method,
     bearer_only = config.bearer_only,
     realm = config.realm,

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -45,7 +45,7 @@ function M.get_options(config, ngx)
     client_secret = config.client_secret,
     discovery = config.discovery,
     introspection_endpoint = config.introspection_endpoint,
-    timeout = config.introspection_timeout,
+    timeout = config.timeout,
     introspection_endpoint_auth_method = config.introspection_endpoint_auth_method,
     bearer_only = config.bearer_only,
     realm = config.realm,


### PR DESCRIPTION
very minor change to allow passing `timeout` property to lua-resty-openidc code. no unit tests included