### PR TITLE
Added support for anonymous usage to chain authentication plugins

### DIFF
--- a/.github/ ISSUE_TEMPLATE.md
+++ b/.github/ ISSUE_TEMPLATE.md
@@ -1,9 +1,0 @@
-1. Used Kong OIDC plugin version:
-
-2. Used Kong version:
-
-3. Kong OIDC plugin configuration:
-
-4. Used OIDC provider:
-
-5. Issue description:

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -4,12 +4,63 @@ local utils = require("kong.plugins.oidc.utils")
 local filter = require("kong.plugins.oidc.filter")
 local session = require("kong.plugins.oidc.session")
 
-local singletons = require "kong.singletons"
 local constants = require "kong.constants"
-local responses = require "kong.tools.responses"
 
-OidcHandler.PRIORITY = 1000
+local kong = kong
 
+OidcHandler.PRIORITY = 1002
+
+local function internal_server_error(err)
+  kong.log.err(err)
+  return kong.response.exit(500, { message = "An unexpected error occurred" })
+end
+
+local function set_consumer(consumer, credential, token)
+  local set_header = kong.service.request.set_header
+  local clear_header = kong.service.request.clear_header
+
+  if consumer and consumer.id then
+    set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
+  else
+    clear_header(constants.HEADERS.CONSUMER_ID)
+  end
+
+  if consumer and consumer.custom_id then
+    set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
+  else
+    clear_header(constants.HEADERS.CONSUMER_CUSTOM_ID)
+  end
+
+  if consumer and consumer.username then
+    set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
+  else
+    clear_header(constants.HEADERS.CONSUMER_USERNAME)
+  end
+
+  kong.client.authenticate(consumer, credential)
+
+  if credential then
+    if token.scope then
+      set_header("x-authenticated-scope", token.scope)
+    else
+      clear_header("x-authenticated-scope")
+    end
+
+    if token.authenticated_userid then
+      set_header("x-authenticated-userid", token.authenticated_userid)
+    else
+      clear_header("x-authenticated-userid")
+    end
+
+    clear_header(constants.HEADERS.ANONYMOUS) -- in case of auth plugins concatenation
+
+  else
+    set_header(constants.HEADERS.ANONYMOUS, true)
+    clear_header("x-authenticated-scope")
+    clear_header("x-authenticated-userid")
+  end
+
+end
 
 function OidcHandler:new()
   OidcHandler.super.new(self, "oidc")
@@ -18,7 +69,7 @@ end
 function OidcHandler:access(config)
   OidcHandler.super.access(self)
 
-  if ngx.ctx.authenticated_credential and config.anonymous ~= "" then
+  if config.anonymous and kong.client.get_credential() then
     -- we're already authenticated, and we're configured for using anonymous,
     -- hence we're in a logical OR between auth methods and we're already done.
     return
@@ -49,6 +100,10 @@ function handle(oidcConfig)
     response = make_oidc(oidcConfig)
     if response then
       if (response.user) then
+        local tmp_user = response.user
+        tmp_user.id = response.user.sub
+        tmp_user.username = response.user.preferred_username
+        set_consumer(tmp_user, nil, nil)
         utils.injectUser(response.user)
       end
       if (response.access_token) then
@@ -69,19 +124,20 @@ function make_oidc(oidcConfig)
       ngx.log(ngx.DEBUG, "Entering recovery page: " .. oidcConfig.recovery_page_path)
       ngx.redirect(oidcConfig.recovery_page_path)
     end
-    if oidcConfig.anonymous ~= "" then
+    if oidcConfig.anonymous then
       -- get anonymous user
-      local consumer_cache_key = singletons.db.consumers:cache_key(oidcConfig.anonymous)
-      local consumer, err      = singletons.cache:get(consumer_cache_key, nil,
-                                                      load_consumer_into_memory,
-                                                      oidcConfig.anonymous, true)
+      local consumer_cache_key = kong.db.consumers:cache_key(oidcConfig.anonymous)
+      local consumer, err      = kong.cache:get(consumer_cache_key, nil,
+                                                load_consumer_into_memory,
+                                                oidcConfig.anonymous, true)
       if err then
-        return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+        return internal_server_error(err)
       end
+
       set_consumer(consumer, nil, nil)
 
     else
-      utils.exit(500, err, ngx.HTTP_INTERNAL_SERVER_ERROR)
+      return kong.response.exit(err.status, err.message, err.headers)
     end
   end
   return res
@@ -93,19 +149,20 @@ function introspect(oidcConfig)
     if err then
       if oidcConfig.bearer_only == "yes" then
         ngx.header["WWW-Authenticate"] = 'Bearer realm="' .. oidcConfig.realm .. '",error="' .. err .. '"'
-        if oidcConfig.anonymous ~= "" then
+        if oidcConfig.anonymous then
           -- get anonymous user
-          local consumer_cache_key = singletons.db.consumers:cache_key(oidcConfig.anonymous)
-          local consumer, err      = singletons.cache:get(consumer_cache_key, nil,
-                                                          load_consumer_into_memory,
-                                                          oidcConfig.anonymous, true)
+          local consumer_cache_key = kong.db.consumers:cache_key(oidcConfig.anonymous)
+          local consumer, err      = kong.cache:get(consumer_cache_key, nil,
+                                                    load_consumer_into_memory,
+                                                    oidcConfig.anonymous, true)
           if err then
-            return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+            return internal_server_error(err)
           end
+    
           set_consumer(consumer, nil, nil)
     
         else
-          utils.exit(ngx.HTTP_UNAUTHORIZED, err, ngx.HTTP_UNAUTHORIZED)
+          return kong.response.exit(err.status, err.message, err.headers)
         end
         
       end
@@ -118,22 +175,6 @@ function introspect(oidcConfig)
 end
 
 -- TESTING
-
-local function set_consumer(consumer, credential, token)
-  ngx_set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
-  ngx_set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
-  ngx_set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
-  ngx.ctx.authenticated_consumer = consumer
-  if credential then
-    ngx_set_header("x-authenticated-scope", token.scope)
-    ngx_set_header("x-authenticated-userid", token.authenticated_userid)
-    ngx.ctx.authenticated_credential = credential
-    ngx_set_header(constants.HEADERS.ANONYMOUS, nil) -- in case of auth plugins concatenation
-  else
-    ngx_set_header(constants.HEADERS.ANONYMOUS, true)
-  end
-
-end
 
 
 return OidcHandler

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -4,6 +4,10 @@ local utils = require("kong.plugins.oidc.utils")
 local filter = require("kong.plugins.oidc.filter")
 local session = require("kong.plugins.oidc.session")
 
+local singletons = require "kong.singletons"
+local constants = require "kong.constants"
+local responses = require "kong.tools.responses"
+
 OidcHandler.PRIORITY = 1000
 
 
@@ -13,6 +17,13 @@ end
 
 function OidcHandler:access(config)
   OidcHandler.super.access(self)
+
+  if ngx.ctx.authenticated_credential and config.anonymous ~= "" then
+    -- we're already authenticated, and we're configured for using anonymous,
+    -- hence we're in a logical OR between auth methods and we're already done.
+    return
+  end
+
   local oidcConfig = utils.get_options(config, ngx)
 
   if filter.shouldProcessRequest(oidcConfig) then
@@ -58,7 +69,20 @@ function make_oidc(oidcConfig)
       ngx.log(ngx.DEBUG, "Entering recovery page: " .. oidcConfig.recovery_page_path)
       ngx.redirect(oidcConfig.recovery_page_path)
     end
-    utils.exit(500, err, ngx.HTTP_INTERNAL_SERVER_ERROR)
+    if oidcConfig.anonymous ~= "" then
+      -- get anonymous user
+      local consumer_cache_key = singletons.db.consumers:cache_key(oidcConfig.anonymous)
+      local consumer, err      = singletons.cache:get(consumer_cache_key, nil,
+                                                      load_consumer_into_memory,
+                                                      oidcConfig.anonymous, true)
+      if err then
+        return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+      end
+      set_consumer(consumer, nil, nil)
+
+    else
+      utils.exit(500, err, ngx.HTTP_INTERNAL_SERVER_ERROR)
+    end
   end
   return res
 end
@@ -69,7 +93,21 @@ function introspect(oidcConfig)
     if err then
       if oidcConfig.bearer_only == "yes" then
         ngx.header["WWW-Authenticate"] = 'Bearer realm="' .. oidcConfig.realm .. '",error="' .. err .. '"'
-        utils.exit(ngx.HTTP_UNAUTHORIZED, err, ngx.HTTP_UNAUTHORIZED)
+        if oidcConfig.anonymous ~= "" then
+          -- get anonymous user
+          local consumer_cache_key = singletons.db.consumers:cache_key(oidcConfig.anonymous)
+          local consumer, err      = singletons.cache:get(consumer_cache_key, nil,
+                                                          load_consumer_into_memory,
+                                                          oidcConfig.anonymous, true)
+          if err then
+            return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+          end
+          set_consumer(consumer, nil, nil)
+    
+        else
+          utils.exit(ngx.HTTP_UNAUTHORIZED, err, ngx.HTTP_UNAUTHORIZED)
+        end
+        
       end
       return nil
     end
@@ -77,6 +115,24 @@ function introspect(oidcConfig)
     return res
   end
   return nil
+end
+
+-- TESTING
+
+local function set_consumer(consumer, credential, token)
+  ngx_set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
+  ngx_set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
+  ngx_set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
+  ngx.ctx.authenticated_consumer = consumer
+  if credential then
+    ngx_set_header("x-authenticated-scope", token.scope)
+    ngx_set_header("x-authenticated-userid", token.authenticated_userid)
+    ngx.ctx.authenticated_credential = credential
+    ngx_set_header(constants.HEADERS.ANONYMOUS, nil) -- in case of auth plugins concatenation
+  else
+    ngx_set_header(constants.HEADERS.ANONYMOUS, true)
+  end
+
 end
 
 

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -23,7 +23,6 @@ return {
           {bearer_only = { type = "string", required = true, default = "no" }},
           {realm = { type = "string", required = true, default = "kong" }},
           {redirect_uri_path = { type = "string" }},
-          {inject_base_path = { type = "string" }},
           {scope = { type = "string", required = true, default = "openid" }},
           {response_type = { type = "string", required = true, default = "code" }},
           {ssl_verify = { type = "string", required = true, default = "no" }},

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -1,24 +1,41 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+local function validate_flows(config)
+
+  return true
+
+end
+
 return {
-  no_consumer = true,
+  name = "oidc",
   fields = {
-    anonymous = { type = "string", uuid = true, legacy = true },
-    client_id = { type = "string", required = true },
-    client_secret = { type = "string", required = true },
-    discovery = { type = "string", required = true, default = "https://.well-known/openid-configuration" },
-    introspection_endpoint = { type = "string", required = false },
-    timeout = { type = "number", required = false },
-    introspection_endpoint_auth_method = { type = "string", required = false },
-    bearer_only = { type = "string", required = true, default = "no" },
-    realm = { type = "string", required = true, default = "kong" },
-    redirect_uri_path = { type = "string" },
-    scope = { type = "string", required = true, default = "openid" },
-    response_type = { type = "string", required = true, default = "code" },
-    ssl_verify = { type = "string", required = true, default = "no" },
-    token_endpoint_auth_method = { type = "string", required = true, default = "client_secret_post" },
-    session_secret = { type = "string", required = false },
-    recovery_page_path = { type = "string" },
-    logout_path = { type = "string", required = false, default = '/logout' },
-    redirect_after_logout_uri = { type = "string", required = false, default = '/' },
-    filters = { type = "string" }
-  }
+    { consumer = typedefs.no_consumer },
+    { config = {
+        type = "record",
+        fields = {
+          { anonymous = { type = "string", uuid = true, legacy = true }, },
+          {client_id = { type = "string", required = true, default = "konglocal" }},
+          {client_secret = { type = "string", required = true, default = "kongapigateway" }},
+          {discovery = { type = "string", required = true, default = "https://cas.example.org:8453/cas/oidc/.well-known/openid-configuration" }},
+          {introspection_endpoint = { type = "string", required = false }},
+          {timeout = { type = "number", required = false }},
+          {introspection_endpoint_auth_method = { type = "string", required = false }},
+          {bearer_only = { type = "string", required = true, default = "no" }},
+          {realm = { type = "string", required = true, default = "kong" }},
+          {redirect_uri_path = { type = "string" }},
+          {inject_base_path = { type = "string" }},
+          {scope = { type = "string", required = true, default = "openid" }},
+          {response_type = { type = "string", required = true, default = "code" }},
+          {ssl_verify = { type = "string", required = true, default = "no" }},
+          {token_endpoint_auth_method = { type = "string", required = true, default = "client_secret_post" }},
+          {session_secret = { type = "string", required = false }},
+          {recovery_page_path = { type = "string" }},
+          {logout_path = { type = "string", required = false, default = '/logout' }},
+          {redirect_after_logout_uri = { type = "string", required = false, default = '/' }},
+          {filters = { type = "string" }}
+        },
+        custom_validator = validate_flows,
+      },
+    },
+  },
 }

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -1,6 +1,7 @@
 return {
   no_consumer = true,
   fields = {
+    anonymous = { type = "string", uuid = true, legacy = true },
     client_id = { type = "string", required = true },
     client_secret = { type = "string", required = true },
     discovery = { type = "string", required = true, default = "https://.well-known/openid-configuration" },

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -41,6 +41,7 @@ end
 
 function M.get_options(config, ngx)
   return {
+    anonymous = config.anonymous,
     client_id = config.client_id,
     client_secret = config.client_secret,
     discovery = config.discovery,


### PR DESCRIPTION
Based on Kong oauth2 official plugin

It was tested/developed against Kong 14.1 CE (as that is what I am using). You/I can easily update to the latest 1.X. You guys should probably version your plugin based in the Kong version supported.

To update to support latest kong 1.x, reference Kong official oath2 plugin for syntax (its mostly differences in kong built-in libraries.