### PR TITLE
added config option forward_bearer_access_token and respective implementation…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Join the chat at https://gitter.im/nokia/kong-oidc](https://badges.gitter.im/nokia/kong-oidc.svg)](https://gitter.im/nokia/kong-oidc?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-**Continuous Integration:** [![Build Status](https://travis-ci.org/nokia/kong-oidc.svg?branch=master)](https://travis-ci.org/nokia/kong-oidc) 
+**Continuous Integration:** [![Build Status](https://travis-ci.org/nokia/kong-oidc.svg?branch=master)](https://travis-ci.org/nokia/kong-oidc)
 [![Coverage Status](https://coveralls.io/repos/github/nokia/kong-oidc/badge.svg?branch=master)](https://coveralls.io/github/nokia/kong-oidc?branch=master) <br/>
 
 **kong-oidc** is a plugin for [Kong](https://github.com/Mashape/kong) implementing the
@@ -62,7 +62,7 @@ If you're using `luarocks` execute the following:
 You also need to set the `KONG_CUSTOM_PLUGINS` environment variable
 
      export KONG_CUSTOM_PLUGINS=oidc
-     
+
 ## Usage
 
 ### Parameters
@@ -82,6 +82,7 @@ You also need to set the `KONG_CUSTOM_PLUGINS` environment variable
 | `config.bearer_only` | no | false | Only introspect tokens without redirecting |
 | `config.realm` | kong | false | Realm used in WWW-Authenticate response header |
 | `config.logout_path` | /logout | false | Absolute path used to logout from the OIDC RP |
+| `config.forward_bearer_access_token` | no | false | Access token is added to upstream request as "Authorization: Bearer ..." header instead of "X-Access-Token" header, may be used if upstream service already has implemented authorization features with bearer token. |
 
 ### Enabling
 
@@ -159,6 +160,10 @@ X-Access-Token: eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJGenFSY0N1Ry13
 X-Id-Token: eyJuYmYiOjAsImF6cCI6ImtvbmciLCJpYXQiOjE1NDg1MTA3NjksImlzcyI6Imh0dHA6XC9cLzE5Mi4xNjguMC45OjgwODBcL2F1dGhcL3JlYWxtc1wvbWFzdGVyIiwiYXVkIjoia29uZyIsIm5vbmNlIjoiZjRkZDQ1NmMwY2U2OGZhZmFiZjRmOGQwN2I0NGFhODYiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiIsImF1dGhfdGltZSI6MTU0ODUxMDY5NywiYWNyIjoiMSIsInNlc3Npb25fc3RhdGUiOiJiNDZmODU2Ny0zODA3LTQ0YmMtYmU1Mi1iMTNiNWQzODI5MTQiLCJleHAiOjE1NDg1MTA4MjksImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwianRpIjoiMjI1ZDRhNDItM2Y3ZC00Y2I2LTkxMmMtOGNkYzM0Y2JiNTk2Iiwic3ViIjoiYTZhNzhkOTEtNTQ5NC00Y2UzLTk1NTUtODc4YTE4NWNhNGI5IiwidHlwIjoiSUQifQ==
 ```
 
+If `config.forward_bearer_access_token` has been set to `yes` then `Authorization`
+header with `Bearer ...` token will be added instead of `X-Access-Token`. This may
+be used if upstream service has already been implemented with JWT bearer access
+token checking.
 
 ## Development
 

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -41,7 +41,11 @@ function handle(oidcConfig)
         utils.injectUser(response.user)
       end
       if (response.access_token) then
-        utils.injectAccessToken(response.access_token)
+        if (oidcConfig.forward_bearer_access_token == "yes") then
+          utils.injectBearerAccessToken(response.access_token)
+        else 
+          utils.injectAccessToken(response.access_token)
+        end
       end
       if (response.id_token) then
         utils.injectIDToken(response.id_token)

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -18,6 +18,7 @@ return {
     recovery_page_path = { type = "string" },
     logout_path = { type = "string", required = false, default = '/logout' },
     redirect_after_logout_uri = { type = "string", required = false, default = '/' },
-    filters = { type = "string" }
+    filters = { type = "string" },
+    forward_bearer_access_token = { type = "string", required = false, default = "no"}
   }
 }

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -58,6 +58,7 @@ function M.get_options(config, ngx)
     filters = parseFilters(config.filters),
     logout_path = config.logout_path,
     redirect_after_logout_uri = config.redirect_after_logout_uri,
+    forward_bearer_access_token = config.forward_bearer_access_token,
   }
 end
 
@@ -69,6 +70,14 @@ end
 
 function M.injectAccessToken(accessToken)
   ngx.req.set_header("X-Access-Token", accessToken)
+end
+
+function M.injectBearerAccessToken(accessToken)
+  local b = "Bearer " .. accessToken
+  --[[
+  ngx.log(ngx.DEBUG, "utils.injectBearerAccessToken(): add Authorization: " .. b)
+  --]]
+  ngx.req.set_header("Authorization", b)
 end
 
 function M.injectIDToken(idToken)


### PR DESCRIPTION
… to forward access token as "Authorization: Bearer ..." header: Access token is added to upstream request as "Authorization: Bearer ..." header instead of "X-Access-Token" header, may be used if upstream service already has implemented authorization features with JWT bearer token.