### PR TITLE
Update README for Kong 1.0.x~ user

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Cache-Control: no-cache
 name=oidc&config.client_id=kong-oidc&config.client_secret=29d98bf7-168c-4874-b8e9-9ba5e7382fa0&config.discovery=https%3A%2F%2F<oidc_provider>%2F.well-known%2Fopenid-configuration
 ```
 
+If you're using Kong 1.0.x or later, `/apis` endpoint has changed to `/<something>/<something_id>/plugins`. You can specify `routes` or `services` or `consumers` as a `something`. For more, see [Kong Admin's API document](https://docs.konghq.com/1.0.x/admin-api/#add-plugin).
+
 To enable the plugin globally:
 ```
 POST /plugins HTTP/1.1

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You also need to set the `KONG_PLUGINS` environment variable
 | `config.session_secret` | | false | Additional parameter, which is used to encrypt the session cookie. Needs to be random |
 | `config.introspection_endpoint` | | false | Token introspection endpoint |
 | `config.timeout` | | false | OIDC endpoint calls timeout |
-| `config.introspection_endpoint_auth_method` | client_secret_basic | false | Token introspection auth method. resty-openidc supports `client_secret_(basic|post)` |
+| `config.introspection_endpoint_auth_method` | client_secret_basic | false | Token introspection auth method. resty-openidc supports `client_secret_(basic\|post)` |
 | `config.bearer_only` | no | false | Only introspect tokens without redirecting |
 | `config.realm` | kong | false | Realm used in WWW-Authenticate response header |
 | `config.logout_path` | /logout | false | Absolute path used to logout from the OIDC RP |


### PR DESCRIPTION
Thank you for your offering this plugin.

I'm using Kong 1.2.x.
At this version, `/apis` endpoint has replaced, so I couldn't add plugin.

I examined [Kong Admin's API document](https://docs.konghq.com/1.0.x/admin-api/#add-plugin) and notice this change happened at vesion 1.0.x boundary.