### PR TITLE
set ngx.ctx.authenticated_groups if groups claim is present

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ ngx.ctx.authenticated_consumer = {
 }
 ```
 
+The plugin will try to retrieve the user's groups from a field in the token (default `groups`)
+and set `ngx.ctx.authenticated_groups` so that Kong authorization plugins can make decisions
+based on the user's group membership.
+
 
 ## Dependencies
 
@@ -82,6 +86,7 @@ You also need to set the `KONG_PLUGINS` environment variable
 | `config.bearer_only` | no | false | Only introspect tokens without redirecting |
 | `config.realm` | kong | false | Realm used in WWW-Authenticate response header |
 | `config.logout_path` | /logout | false | Absolute path used to logout from the OIDC RP |
+| `config.groups_claim` | groups | false | Name of the claim in the token to get groups from |
 
 ### Enabling
 

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -39,6 +39,7 @@ function handle(oidcConfig)
     if response then
       if (response.user) then
         utils.injectUser(response.user)
+        utils.injectGroups(response.user, oidcConfig.groups_claim)
       end
       if (response.access_token) then
         utils.injectAccessToken(response.access_token)

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -18,6 +18,7 @@ return {
     recovery_page_path = { type = "string" },
     logout_path = { type = "string", required = false, default = '/logout' },
     redirect_after_logout_uri = { type = "string", required = false, default = '/' },
-    filters = { type = "string" }
+    filters = { type = "string" },
+    groups_claim = { type = "string", required = false, default = "groups" }
   }
 }

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -58,6 +58,7 @@ function M.get_options(config, ngx)
     filters = parseFilters(config.filters),
     logout_path = config.logout_path,
     redirect_after_logout_uri = config.redirect_after_logout_uri,
+    groups_claim = config.groups_claim,
   }
 end
 
@@ -83,6 +84,12 @@ function M.injectUser(user)
   ngx.ctx.authenticated_credential = tmp_user
   local userinfo = cjson.encode(user)
   ngx.req.set_header("X-Userinfo", ngx.encode_base64(userinfo))
+end
+
+function M.injectGroups(user, claim)
+  if user[claim] ~= nil then
+    ngx.ctx.authenticated_groups = user[claim]
+  end
 end
 
 function M.has_bearer_access_token()


### PR DESCRIPTION
This inspects the token retrieved from the OIDC provider, checks if the `groups` claim is present, and then sets the appropriate variable in the NGINX context so that other Kong plugins, such as the [bundled ACL plugin](https://docs.konghq.com/hub/kong-inc/acl/) can make authorization decisions based on the user's group vector.

This is following up on @Trojan295's ask for adding more information to the context (https://github.com/nokia/kong-oidc/issues/15#issuecomment-340862575).