### PR TITLE
Add http_proxy and https_proxy to params.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ You also need to set the `KONG_PLUGINS` environment variable
 | `config.logout_path` | /logout | false | Absolute path used to logout from the OIDC RP |
 | `config.http_proxy` || false | HTTP proxy URL (e.g. http://proxy.local:8888/) |
 | `config.https_proxy` || false | HTTPS proxy URL (e.g. http://proxy.local:8888/) |
+| `config.http_proxy_authorization` || false | `Proxy-Authorization` header value to be used with `config.http_proxy` (e.g. `Basic ZGVtbzp0ZXN0`) |
+| `config.https_proxy_authorization` || false | `Proxy-Authorization` header value to be used with `config.https_proxy` (e.g. `Basic ZGVtbzp0ZXN0`) |
 
 ### Enabling
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Join the chat at https://gitter.im/nokia/kong-oidc](https://badges.gitter.im/nokia/kong-oidc.svg)](https://gitter.im/nokia/kong-oidc?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-**Continuous Integration:** [![Build Status](https://travis-ci.org/nokia/kong-oidc.svg?branch=master)](https://travis-ci.org/nokia/kong-oidc) 
+**Continuous Integration:** [![Build Status](https://travis-ci.org/nokia/kong-oidc.svg?branch=master)](https://travis-ci.org/nokia/kong-oidc)
 [![Coverage Status](https://coveralls.io/repos/github/nokia/kong-oidc/badge.svg?branch=master)](https://coveralls.io/github/nokia/kong-oidc?branch=master) <br/>
 
 **kong-oidc** is a plugin for [Kong](https://github.com/Mashape/kong) implementing the
@@ -62,7 +62,7 @@ If you're using `luarocks` execute the following:
 You also need to set the `KONG_PLUGINS` environment variable
 
      export KONG_PLUGINS=oidc
-     
+
 ## Usage
 
 ### Parameters
@@ -82,6 +82,8 @@ You also need to set the `KONG_PLUGINS` environment variable
 | `config.bearer_only` | no | false | Only introspect tokens without redirecting |
 | `config.realm` | kong | false | Realm used in WWW-Authenticate response header |
 | `config.logout_path` | /logout | false | Absolute path used to logout from the OIDC RP |
+| `config.http_proxy` || false | HTTP proxy URL (e.g. http://proxy.local:8888/) |
+| `config.https_proxy` || false | HTTPS proxy URL (e.g. http://proxy.local:8888/) |
 
 ### Enabling
 

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -21,5 +21,7 @@ return {
     filters = { type = "string" },
     http_proxy = { type = "string", required = false },
     https_proxy = { type = "string", required = false },
+    http_proxy_authorization  = { type = "string", required = false },
+    https_proxy_authorization = { type = "string", required = false },
   }
 }

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -18,6 +18,8 @@ return {
     recovery_page_path = { type = "string" },
     logout_path = { type = "string", required = false, default = '/logout' },
     redirect_after_logout_uri = { type = "string", required = false, default = '/' },
-    filters = { type = "string" }
+    filters = { type = "string" },
+    http_proxy = { type = "string", required = false },
+    https_proxy = { type = "string", required = false },
   }
 }

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -40,6 +40,14 @@ function M.get_redirect_uri_path(ngx)
 end
 
 function M.get_options(config, ngx)
+  local proxy_opts
+  if config.http_proxy or config.https_proxy then
+    proxy_opts = {
+      http_proxy = config.http_proxy,
+      https_proxy = config.https_proxy,
+    }
+  end
+
   return {
     client_id = config.client_id,
     client_secret = config.client_secret,
@@ -58,6 +66,7 @@ function M.get_options(config, ngx)
     filters = parseFilters(config.filters),
     logout_path = config.logout_path,
     redirect_after_logout_uri = config.redirect_after_logout_uri,
+    proxy_opts = proxy_opts,
   }
 end
 

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -45,6 +45,8 @@ function M.get_options(config, ngx)
     proxy_opts = {
       http_proxy = config.http_proxy,
       https_proxy = config.https_proxy,
+      http_proxy_authorization = config.http_proxy_authorization,
+      https_proxy_authorization = config.https_proxy_authorization,
     }
   end
 


### PR DESCRIPTION
This enhance enables to pass http_proxy and https_proxy options to lua-resty-openidc and use a proxy for communication with OIDC provider.