### PR TITLE
Check for true as well as 'yes' to avoid confusion

### DIFF
--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -64,10 +64,11 @@ function make_oidc(oidcConfig)
 end
 
 function introspect(oidcConfig)
-  if utils.has_bearer_access_token() or oidcConfig.bearer_only == "yes" then
+  local bearerOnly = oidcConfig.bearer_only == true or oidcConfig.bearer_only == "yes"
+  if utils.has_bearer_access_token() or bearerOnly then
     local res, err = require("resty.openidc").introspect(oidcConfig)
     if err then
-      if oidcConfig.bearer_only == "yes" then
+      if bearerOnly then
         ngx.header["WWW-Authenticate"] = 'Bearer realm="' .. oidcConfig.realm .. '",error="' .. err .. '"'
         utils.exit(ngx.HTTP_UNAUTHORIZED, err, ngx.HTTP_UNAUTHORIZED)
       end


### PR DESCRIPTION
With kong in DB-free mode, if you specify `bearer_only: yes` in your kong.yml file, it will get parsed as `true` which causes the check to fail since it uses `oidcConfig.bearer_only == "yes"`

This can be pretty confusing and tripped me up for a bit. I propose checking for true in addition to "yes"

This resolves:
https://github.com/nokia/kong-oidc/issues/144