### PR TITLE
Adding support for JWKS-based token validation and token attribute mapping

### DIFF
--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -13,11 +13,13 @@ return {
     scope = { type = "string", required = true, default = "openid" },
     response_type = { type = "string", required = true, default = "code" },
     ssl_verify = { type = "string", required = true, default = "no" },
+    use_jwks = { type = "string", required = true, default = "no" },
     token_endpoint_auth_method = { type = "string", required = true, default = "client_secret_post" },
     session_secret = { type = "string", required = false },
     recovery_page_path = { type = "string" },
     logout_path = { type = "string", required = false, default = '/logout' },
     redirect_after_logout_uri = { type = "string", required = false, default = '/' },
-    filters = { type = "string" }
+    filters = { type = "string" },
+    mappings = { type = "array", default = {}, }
   }
 }

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -86,19 +86,21 @@ function M.injectUser(user, oidcConfig)
   local userinfo = cjson.encode(user)
   ngx.req.set_header("X-Userinfo", ngx.encode_base64(userinfo))
 
-  for i, value in ipairs(oidcConfig.mappings) do
-    local f, from, to
-    f = string.gmatch(value, "[^:]+")
-    from = f()
-    to = f()
-    if from ~= nil and to ~= nil then
-      if user[from] ~= nil then
-        ngx.req.set_header(to, user[from])
+  if oidcConfig.mappings ~= nil then
+    for i, value in ipairs(oidcConfig.mappings) do
+      local f, from, to
+      f = string.gmatch(value, "[^:]+")
+      from = f()
+      to = f()
+      if from ~= nil and to ~= nil then
+        if user[from] ~= nil then
+          ngx.req.set_header(to, user[from])
+        else
+          ngx.log(ngx.WARN, "Key '" .. from .. "' not present on token")
+        end
       else
-        ngx.log(ngx.WARN, "Key '" .. from .. "' not present on token")
+        ngx.log(ngx.ERR, "Ignoring incorrect configuration: " .. value)
       end
-    else
-      ngx.log(ngx.ERR, "Ignoring incorrect configuration: " .. value)
     end
   end
 end

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -53,11 +53,13 @@ function M.get_options(config, ngx)
     scope = config.scope,
     response_type = config.response_type,
     ssl_verify = config.ssl_verify,
+    use_jwks = config.use_jwks,
     token_endpoint_auth_method = config.token_endpoint_auth_method,
     recovery_page_path = config.recovery_page_path,
     filters = parseFilters(config.filters),
     logout_path = config.logout_path,
     redirect_after_logout_uri = config.redirect_after_logout_uri,
+    mappings = config.mappings,
   }
 end
 
@@ -76,13 +78,29 @@ function M.injectIDToken(idToken)
   ngx.req.set_header("X-ID-Token", ngx.encode_base64(tokenStr))
 end
 
-function M.injectUser(user)
+function M.injectUser(user, oidcConfig)
   local tmp_user = user
   tmp_user.id = user.sub
   tmp_user.username = user.preferred_username
   ngx.ctx.authenticated_credential = tmp_user
   local userinfo = cjson.encode(user)
   ngx.req.set_header("X-Userinfo", ngx.encode_base64(userinfo))
+
+  for i, value in ipairs(oidcConfig.mappings) do
+    local f, from, to
+    f = string.gmatch(value, "[^:]+")
+    from = f()
+    to = f()
+    if from ~= nil and to ~= nil then
+      if user[from] ~= nil then
+        ngx.req.set_header(to, user[from])
+      else
+        ngx.log(ngx.WARN, "Key '" .. from .. "' not present on token")
+      end
+    else
+      ngx.log(ngx.ERR, "Ignoring incorrect configuration: " .. value)
+    end
+  end
 end
 
 function M.has_bearer_access_token()

--- a/test/unit/mockable_case.lua
+++ b/test/unit/mockable_case.lua
@@ -8,6 +8,7 @@ function MockableCase:setUp()
   self.mocked_ngx = {
     DEBUG = "debug",
     ERR = "error",
+    WARN = "warn",
     HTTP_UNAUTHORIZED = 401,
     ctx = {},
     header = {},


### PR DESCRIPTION
Adds support for JWKS-based token validation (#150) and also extracting token attributes as HTTP headers (besides the `X-Userinfo` header)