### PR TITLE
Fix formatting of allowed auth methods in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You also need to set the `KONG_PLUGINS` environment variable
 | `config.session_secret` | | false | Additional parameter, which is used to encrypt the session cookie. Needs to be random |
 | `config.introspection_endpoint` | | false | Token introspection endpoint |
 | `config.timeout` | | false | OIDC endpoint calls timeout |
-| `config.introspection_endpoint_auth_method` | client_secret_basic | false | Token introspection auth method. resty-openidc supports `client_secret_(basic|post)` |
+| `config.introspection_endpoint_auth_method` | client_secret_basic | false | Token introspection auth method. resty-openidc supports `client_secret_basic` and `client_secret_post` |
 | `config.bearer_only` | no | false | Only introspect tokens without redirecting |
 | `config.realm` | kong | false | Realm used in WWW-Authenticate response header |
 | `config.logout_path` | /logout | false | Absolute path used to logout from the OIDC RP |


### PR DESCRIPTION
GitHub Markdown caps the display due to the `|` separator. This Pull Request just spells out both options to avoid the formatting problem.