### PR TITLE
add X-Credential-Identifier

### DIFF
--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -83,6 +83,7 @@ function M.injectUser(user)
   ngx.ctx.authenticated_credential = tmp_user
   local userinfo = cjson.encode(user)
   ngx.req.set_header("X-Userinfo", ngx.encode_base64(userinfo))
+  ngx.req.set_header("X-Credential-Identifier", user.username)
 end
 
 function M.has_bearer_access_token()


### PR DESCRIPTION
Start from Kong 2.1, there is a new http header indicate the authorized customer, according to https://docs.konghq.com/hub/kong-inc/basic-auth/ , https://docs.konghq.com/hub/kong-inc/ldap-auth/ and https://docs.konghq.com/hub/kong-inc/key-auth/.
Therefore I think there should be X-Credential-Identifier in order to align with other auth plugins.
Besides, X-UserInfo and X-Credential-Identifier should be cleared before authentication process, however I could not find the proper place to do this. Hope you guru can complete this PR :)