### PR TITLE
Added authorization_params support

### DIFF
--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -19,6 +19,6 @@ return {
     logout_path = { type = "string", required = false, default = '/logout' },
     redirect_after_logout_uri = { type = "string", required = false, default = '/' },
     filters = { type = "string" },
-    authorization_params = { type = "array", required = false }
+    authorization_params = { type = "table", required = false }
   }
 }

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -18,6 +18,7 @@ return {
     recovery_page_path = { type = "string" },
     logout_path = { type = "string", required = false, default = '/logout' },
     redirect_after_logout_uri = { type = "string", required = false, default = '/' },
-    filters = { type = "string" }
+    filters = { type = "string" },
+    authorization_params = { type = "string", required = false }
   }
 }

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -19,6 +19,6 @@ return {
     logout_path = { type = "string", required = false, default = '/logout' },
     redirect_after_logout_uri = { type = "string", required = false, default = '/' },
     filters = { type = "string" },
-    authorization_params = { type = "table", required = false }
+    authorization_params = { type = "array", required = false }
   }
 }

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -19,6 +19,6 @@ return {
     logout_path = { type = "string", required = false, default = '/logout' },
     redirect_after_logout_uri = { type = "string", required = false, default = '/' },
     filters = { type = "string" },
-    authorization_params = { type = "string", required = false }
+    authorization_params = { type = "table", required = false }
   }
 }

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -12,23 +12,6 @@ local function parseFilters(csvFilters)
   return filters
 end
 
-local function parseAuthorizationParams(params)
-  local resultParams = {}
-  if (not (params == nil)) then
-    for i, name in ipairs(params) do
-      local split = {}
-      for e, pattern in string.gmatch(name, "(.+)=(.+)") do
-        split[e] = pattern
-        table.insert(split, e)
-        table.insert(split, pattern)
-      end
-      resultParams[split[1]] = split[2]
-    end
-  end
-  
-  return resultParams
-end
-
 function M.get_redirect_uri_path(ngx)
   local function drop_query()
     local uri = ngx.var.request_uri

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -58,7 +58,7 @@ function M.get_options(config, ngx)
     filters = parseFilters(config.filters),
     logout_path = config.logout_path,
     redirect_after_logout_uri = config.redirect_after_logout_uri,
-    authorization_params = parseAuthorizationParams(config.authorization_params),
+    authorization_params = config.authorization_params,
   }
 end
 

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -58,6 +58,7 @@ function M.get_options(config, ngx)
     filters = parseFilters(config.filters),
     logout_path = config.logout_path,
     redirect_after_logout_uri = config.redirect_after_logout_uri,
+    authorization_params = config.authorization_params,
   }
 end
 

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -17,14 +17,11 @@ local function parseAuthorizationParams(params)
   if (not (params == nil)) then
     for i, name in ipairs(params) do
       local split = {}
-        print(name)
-      for e, pattern in string.gmatch(name, "(%w+)=(%w+)") do
+      for e, pattern in string.gmatch(name, "(.+)=(.+)") do
         split[e] = pattern
         table.insert(split, e)
         table.insert(split, pattern)
       end
-        print(split[1])
-        print(split[2])
       resultParams[split[1]] = split[2]
     end
   end

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -12,6 +12,26 @@ local function parseFilters(csvFilters)
   return filters
 end
 
+local function parseAuthorizationParams(params)
+  local resultParams = {}
+  if (not (params == nil)) then
+    for i, name in ipairs(params) do
+      local split = {}
+        print(name)
+      for e, pattern in string.gmatch(name, "(%w+)=(%w+)") do
+        split[e] = pattern
+        table.insert(split, e)
+        table.insert(split, pattern)
+      end
+        print(split[1])
+        print(split[2])
+      resultParams[split[1]] = split[2]
+    end
+  end
+  
+  return resultParams
+end
+
 function M.get_redirect_uri_path(ngx)
   local function drop_query()
     local uri = ngx.var.request_uri
@@ -58,7 +78,7 @@ function M.get_options(config, ngx)
     filters = parseFilters(config.filters),
     logout_path = config.logout_path,
     redirect_after_logout_uri = config.redirect_after_logout_uri,
-    authorization_params = config.authorization_params,
+    authorization_params = parseAuthorizationParams(config.authorization_params),
   }
 end
 


### PR DESCRIPTION
This will fix #200 by the additional table parameter `authorization_params` which is supported by the base library https://github.com/zmartzone/lua-resty-openidc

Sorry for the many commits but I was struggling with table handling from k8s yaml and used before an array instead of table.