### PR TITLE
Add redirect_uri_scheme

### DIFF
--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -10,6 +10,7 @@ return {
     bearer_only = { type = "string", required = true, default = "no" },
     realm = { type = "string", required = true, default = "kong" },
     redirect_uri_path = { type = "string" },
+    redirect_uri_scheme = { type = "string" },
     scope = { type = "string", required = true, default = "openid" },
     response_type = { type = "string", required = true, default = "code" },
     ssl_verify = { type = "string", required = true, default = "no" },

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -50,6 +50,7 @@ function M.get_options(config, ngx)
     bearer_only = config.bearer_only,
     realm = config.realm,
     redirect_uri_path = config.redirect_uri_path or M.get_redirect_uri_path(ngx),
+    redirect_uri_scheme = config.redirect_uri_scheme,
     scope = config.scope,
     response_type = config.response_type,
     ssl_verify = config.ssl_verify,


### PR DESCRIPTION
With the need to specify which schema I will redirect to, http or https the change will allow this control to be at the user's discretion, just fill in the redirect_uri_scheme field.